### PR TITLE
Feature: Supabase Postgres Support

### DIFF
--- a/container/supabase_postgres.go
+++ b/container/supabase_postgres.go
@@ -1,0 +1,91 @@
+package container
+
+import (
+	"github.com/4ND3R50N/testsetup"
+	"github.com/ory/dockertest"
+	"github.com/ory/dockertest/docker"
+	"strconv"
+)
+
+type supabasePostgres struct {
+	hostName string
+	Port     int
+	Opts     testsetup.DockerContainerOpts
+	r        *dockertest.Resource
+}
+
+type SupabasePostgresContainerOpts struct {
+	ContainerName string
+	NetworkID     string
+	DBName        string
+	DBPass        string
+	// ExternalDBHost is the hostname the container is reachable at.
+	// For DinD environments this is "docker", for local testing it
+	// is "localhost". If empty "docker" will be set if running in
+	// a CI environment and "localhost" otherwise.
+	ExternalDBHost string
+	DBExternalPort string
+	DBInternalPort string
+}
+
+func WithSupabasePostgres(opts SupabasePostgresContainerOpts) testsetup.Container {
+	opts.ExternalDBHost = validateHost(opts.ExternalDBHost)
+	port, _ := strconv.Atoi(opts.ExternalDBHost)
+	return &supabasePostgres{
+		Port: port,
+		Opts: testsetup.DockerContainerOpts{
+			ContainerName: opts.ContainerName,
+			Repository:    "supabase/postgres",
+			Tag:           "15.6.1.121",
+			NetworkID:     opts.NetworkID,
+			PortBinding:   map[string]string{opts.DBExternalPort: opts.DBInternalPort},
+			Env: map[string]string{
+				"POSTGRES_PORT":     opts.DBInternalPort,
+				"PGPORT":            opts.DBInternalPort,
+				"POSTGRES_DB":       opts.DBName,
+				"PGDATABASE":        opts.DBName,
+				"POSTGRES_PASSWORD": opts.DBPass,
+				"PGPASSWORD":        opts.DBPass,
+			},
+			ExpireTime: 5,
+			HealthCheck: func(pool *dockertest.Pool, resource *dockertest.Resource) error {
+				if err := waitForPostgres(pool,
+					opts.ExternalDBHost,
+					opts.DBExternalPort,
+					opts.DBName,
+					"postgres",
+					opts.DBPass,
+					"disable"); err != nil {
+					return err
+				}
+				return nil
+			},
+		},
+	}
+}
+
+func (s *supabasePostgres) GetHostname() string {
+	return s.hostName
+}
+
+func (s *supabasePostgres) GetPorts() []int {
+	return []int{s.Port}
+}
+
+func (s *supabasePostgres) Start(auth docker.AuthConfiguration, pool *dockertest.Pool) error {
+	resource, hostname, err := testsetup.RunDockerContainer(auth, pool, s.Opts)
+	if err != nil {
+		return err
+	}
+	s.hostName = *hostname
+	s.r = resource
+	return nil
+}
+
+func (s *supabasePostgres) Stop() error {
+	return s.r.Close()
+}
+
+func (s *supabasePostgres) SetLabel(label map[string]string) {
+	s.Opts.Labels = label
+}

--- a/testsetup_test.go
+++ b/testsetup_test.go
@@ -30,6 +30,17 @@ func TestTestSetup_Start(t *testing.T) {
 		DBInternalPort: "5432",
 	}
 
+	supabasePostgresContainerName := "supabase-" + uuid.New().String()
+	supabasePostgres := container.SupabasePostgresContainerOpts{
+		ContainerName:  supabasePostgresContainerName,
+		NetworkID:      networkID,
+		DBName:         "test",
+		DBPass:         "test",
+		ExternalDBHost: container.AutoGuessHostname(),
+		DBExternalPort: "54321",
+		DBInternalPort: "5432",
+	}
+
 	zookeeperContainerName := "zookeeper-" + uuid.New().String()
 	zookeeper := container.ZookeeperOpts{
 		ContainerName: zookeeperContainerName,
@@ -50,6 +61,7 @@ func TestTestSetup_Start(t *testing.T) {
 	testSetup := testsetup.NewTestSetup(docker.AuthConfiguration{},
 		networkID,
 		container.WithPostgres(postgres),
+		container.WithSupabasePostgres(supabasePostgres),
 		container.WithZookeeper(zookeeper),
 		container.WithKafka(kafkaContainerOpts, "your.topic.1", "your.topic.2"))
 	testSetup.Start()
@@ -60,6 +72,9 @@ func TestTestSetup_Start(t *testing.T) {
 	networkID2 := "TestTestSetup_Start-" + uuid.New().String()
 	postgres.ContainerName = postgresContainerName + "-2"
 	postgres.DBExternalPort = "5433"
+
+	supabasePostgres.ContainerName = supabasePostgresContainerName + "-2"
+	supabasePostgres.DBExternalPort = "54323"
 
 	zookeeper.ContainerName = zookeeperContainerName + "-2"
 	zookeeper.Port = "2182"
@@ -73,6 +88,7 @@ func TestTestSetup_Start(t *testing.T) {
 	testSetup2 := testsetup.NewTestSetup(docker.AuthConfiguration{},
 		networkID2,
 		container.WithPostgres(postgres),
+		container.WithSupabasePostgres(supabasePostgres),
 		container.WithZookeeper(zookeeper),
 		container.WithKafka(kafkaContainerOpts, "your.topic.1", "your.topic.2"))
 	testSetup2.Start()


### PR DESCRIPTION
Adds support to test against a locally hosted supabase postgres database.
Limitation: the default user `postgres` cannot be changed.